### PR TITLE
исправление видимости ссылок в меню лаунчера

### DIFF
--- a/Content.Client/Launcher/LauncherConnectingGui.xaml.cs
+++ b/Content.Client/Launcher/LauncherConnectingGui.xaml.cs
@@ -62,17 +62,17 @@ namespace Content.Client.Launcher
             ExitButton.OnPressed += _ => _state.Exit();
 
             // LOP edit start
-            OpenDiscordButton.OnPressed += _ => IoCManager.Resolve<IUriOpener>().OpenUri(linkDiscord);
-            OpenWikiButton.OnPressed += _ => IoCManager.Resolve<IUriOpener>().OpenUri(linkWiki);
-            OpenWebsiteButton.OnPressed += _ => IoCManager.Resolve<IUriOpener>().OpenUri(linkWebsite);
-            OpenGithubButton.OnPressed += _ => IoCManager.Resolve<IUriOpener>().OpenUri(linkGithub);
-            OpenForumButton.OnPressed += _ => IoCManager.Resolve<IUriOpener>().OpenUri(linkForum);
-
             OpenDiscordButton.Visible = _cfg.GetCVar(CCVars.InfoLinksDiscord) != "";
             OpenWikiButton.Visible = _cfg.GetCVar(CCVars.InfoLinksWiki) != "";
             OpenWebsiteButton.Visible = _cfg.GetCVar(CCVars.InfoLinksWebsite) != "";
             OpenGithubButton.Visible = _cfg.GetCVar(CCVars.InfoLinksGithub) != "";
             OpenForumButton.Visible = _cfg.GetCVar(CCVars.InfoLinksForum) != "";
+
+            OpenDiscordButton.OnPressed += _ => IoCManager.Resolve<IUriOpener>().OpenUri(linkDiscord);
+            OpenWikiButton.OnPressed += _ => IoCManager.Resolve<IUriOpener>().OpenUri(linkWiki);
+            OpenWebsiteButton.OnPressed += _ => IoCManager.Resolve<IUriOpener>().OpenUri(linkWebsite);
+            OpenGithubButton.OnPressed += _ => IoCManager.Resolve<IUriOpener>().OpenUri(linkGithub);
+            OpenForumButton.OnPressed += _ => IoCManager.Resolve<IUriOpener>().OpenUri(linkForum);
             // LOP edit end
 
             var addr = state.Address;


### PR DESCRIPTION
## Исправление отображение ссылок колонки ссылок
### Проблема была в неверное последовательности кода инициализации: сначала загружались кнопки, а уже потом их видимость, поэтому при обратно возвращении в меню лаунчера - позже отображалась видимость ссылок.

**Проверки**
- [X] PR завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
- [X] Я не добавлял контент нарушающий чужие авторские права.
- [X] Я добавил свой контент только в папку _NewParadise(только если вы не меняете оригинальный код).
- [X] Я не добавлял переводы в прототипы, а сделал их с помощью скрипта translations.bat в Tools/SS14_RU.
- [X] Я не добавлял лишние изменения в PR. Т.е. 1 идея/задача на 1 PR.
- [X] Я пометил свои изменения в оригинальном коде смотря на CONTRIBUTING.md.

:cl: Kasey
- fix: Исправлено отображение ссылок в меню лаунчера
